### PR TITLE
Version release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pebble_auto_config",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PAC is a simple configuration page for pebble watchface configuration. PAC uses url parameters to create a config page on the fly using JS.",
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,8 @@
     "copy:bootstrap": "cp ./node_modules/bootstrap/dist/css/bootstrap.min.css ./css",
     "copy:jquery": "cp ./node_modules/jquery/dist/jquery.min.js ./js",
     "copy:handlebars": "cp ./node_modules/handlebars/dist/handlebars.min.js ./js",
-    "copy:all": "npm run copy:bootstrap && npm run copy:jquery && npm run copy:handlebars"
+    "copy:all": "npm run copy:bootstrap && npm run copy:jquery && npm run copy:handlebars",
+    "postversion": "touch ./test-$npm_package_version.html"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`postversion`: Run AFTER bump the package version. This is a default script provided by npm ([link](https://docs.npmjs.com/misc/scripts#description))
`$npm_package_version`: The package.json fields are tacked onto the npm_package_ prefix ([link](https://docs.npmjs.com/misc/scripts#packagejson-vars))

You can run `npm version patch|minor|major` ([link](https://docs.npmjs.com/cli/version)) to automatically update your `package.json` with the correct version. Then, the `postversion` script will run automatically, and you'll have access to the new, bumped version number via the `$npm_package_version` variable. At this point, you could do something like `mkdir -p dist/$npm_package_version`. In this PR, I just made a file with the version number to test that it worked.
